### PR TITLE
Implement user CRUD in hexagonal architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Domain modelleri (`domain` paketi) yalnizca gerekli alanlari barindirir ve dis k
    go run ./cmd/api
    ```
 3. HTTP servisi varsayilan olarak Fiber uzerinde belirttiginiz portta calisir ve `/api/notifications/trigger` rotasi ile bildirim tetikler.
+4. Kullanici islemleri icin `/api/users` (POST), `/api/users/:id` (PUT, DELETE) rotalari kullanilabilir.
 
 ## Sonuc
 

--- a/internal/adapters/http/router.go
+++ b/internal/adapters/http/router.go
@@ -13,6 +13,11 @@ func (a *Adapter) registerRoutes(authUser string, authPassword string) {
 		},
 	}))
 
-	// Register your routes here
+	// Notification routes
 	api.Post("/notifications/trigger", a.TriggerNotificationHandler)
+
+	// User management routes
+	api.Post("/users", a.CreateUserHandler)
+	api.Put("/users/:id", a.UpdateUserHandler)
+	api.Delete("/users/:id", a.DeleteUserHandler)
 }

--- a/internal/adapters/http/user_handler.go
+++ b/internal/adapters/http/user_handler.go
@@ -1,0 +1,39 @@
+package http
+
+import (
+	"encoding/json"
+	"github.com/aknEvrnky/notification-system/internal/application/core/domain"
+	"github.com/gofiber/fiber/v2"
+)
+
+func (a *Adapter) CreateUserHandler(ctx *fiber.Ctx) error {
+	var user domain.User
+	if err := json.Unmarshal(ctx.Body(), &user); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid payload")
+	}
+	if err := a.api.CreateUser(ctx.Context(), user); err != nil {
+		return err
+	}
+	return ctx.Status(fiber.StatusCreated).Send([]byte("user created"))
+}
+
+func (a *Adapter) UpdateUserHandler(ctx *fiber.Ctx) error {
+	id := ctx.Params("id")
+	var user domain.User
+	if err := json.Unmarshal(ctx.Body(), &user); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid payload")
+	}
+	user.Id = id
+	if err := a.api.UpdateUser(ctx.Context(), user); err != nil {
+		return err
+	}
+	return ctx.Send([]byte("user updated"))
+}
+
+func (a *Adapter) DeleteUserHandler(ctx *fiber.Ctx) error {
+	id := ctx.Params("id")
+	if err := a.api.DeleteUser(ctx.Context(), id); err != nil {
+		return err
+	}
+	return ctx.Send([]byte("user deleted"))
+}

--- a/internal/adapters/repository/orm/user_repository.go
+++ b/internal/adapters/repository/orm/user_repository.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-type user struct {
+type User struct {
 	gorm.Model
 	ID          string `gorm:"primarykey"`
 	Name        string
@@ -22,6 +22,7 @@ type UserRepository struct {
 }
 
 func NewUserRepository(db *gorm.DB) *UserRepository {
+	db.AutoMigrate(&User{})
 	return &UserRepository{db: db}
 }
 
@@ -29,7 +30,7 @@ func (u *UserRepository) FindById(ctx context.Context, userId string) (domain.Us
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	usr := user{ID: userId}
+	usr := User{ID: userId}
 
 	u.db.First(&usr)
 
@@ -53,7 +54,7 @@ func (u *UserRepository) Create(ctx context.Context, usr domain.User) error {
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	record := user{
+	record := User{
 		ID:          usr.Id,
 		Name:        usr.Name,
 		Email:       usr.Email,
@@ -68,7 +69,7 @@ func (u *UserRepository) Update(ctx context.Context, usr domain.User) error {
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	record := user{
+	record := User{
 		ID:          usr.Id,
 		Name:        usr.Name,
 		Email:       usr.Email,
@@ -76,12 +77,12 @@ func (u *UserRepository) Update(ctx context.Context, usr domain.User) error {
 		DeviceToken: usr.DeviceToken,
 	}
 
-	return u.db.WithContext(ctx).Model(&user{}).Where("id = ?", usr.Id).Updates(record).Error
+	return u.db.WithContext(ctx).Model(&User{}).Where("id = ?", usr.Id).Updates(record).Error
 }
 
 func (u *UserRepository) Delete(ctx context.Context, userId string) error {
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	return u.db.WithContext(ctx).Where("id = ?", userId).Delete(&user{}).Error
+	return u.db.WithContext(ctx).Where("id = ?", userId).Delete(&User{}).Error
 }

--- a/internal/adapters/repository/orm/user_repository.go
+++ b/internal/adapters/repository/orm/user_repository.go
@@ -48,3 +48,40 @@ func (u *UserRepository) FindById(ctx context.Context, userId string) (domain.Us
 		DeviceToken: usr.DeviceToken,
 	}, nil
 }
+
+func (u *UserRepository) Create(ctx context.Context, usr domain.User) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	record := user{
+		ID:          usr.Id,
+		Name:        usr.Name,
+		Email:       usr.Email,
+		Phone:       usr.Phone,
+		DeviceToken: usr.DeviceToken,
+	}
+
+	return u.db.WithContext(ctx).Create(&record).Error
+}
+
+func (u *UserRepository) Update(ctx context.Context, usr domain.User) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	record := user{
+		ID:          usr.Id,
+		Name:        usr.Name,
+		Email:       usr.Email,
+		Phone:       usr.Phone,
+		DeviceToken: usr.DeviceToken,
+	}
+
+	return u.db.WithContext(ctx).Model(&user{}).Where("id = ?", usr.Id).Updates(record).Error
+}
+
+func (u *UserRepository) Delete(ctx context.Context, userId string) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	return u.db.WithContext(ctx).Where("id = ?", userId).Delete(&user{}).Error
+}

--- a/internal/application/core/api/use_case_user.go
+++ b/internal/application/core/api/use_case_user.go
@@ -1,0 +1,18 @@
+package api
+
+import (
+	"context"
+	"github.com/aknEvrnky/notification-system/internal/application/core/domain"
+)
+
+func (a *Application) CreateUser(ctx context.Context, user domain.User) error {
+	return a.UserRepository.Create(ctx, user)
+}
+
+func (a *Application) UpdateUser(ctx context.Context, user domain.User) error {
+	return a.UserRepository.Update(ctx, user)
+}
+
+func (a *Application) DeleteUser(ctx context.Context, id string) error {
+	return a.UserRepository.Delete(ctx, id)
+}

--- a/internal/ports/api.go
+++ b/internal/ports/api.go
@@ -1,8 +1,14 @@
 package ports
 
-import "context"
+import (
+	"context"
+	"github.com/aknEvrnky/notification-system/internal/application/core/domain"
+)
 
 type ApiPort interface {
 	GetVersion() string
 	TriggerNotification(ctx context.Context, eventType string, payload map[string]any) error
+	CreateUser(ctx context.Context, user domain.User) error
+	UpdateUser(ctx context.Context, user domain.User) error
+	DeleteUser(ctx context.Context, id string) error
 }

--- a/internal/ports/repository.go
+++ b/internal/ports/repository.go
@@ -7,4 +7,7 @@ import (
 
 type UserRepository interface {
 	FindById(ctx context.Context, userId string) (domain.User, error)
+	Create(ctx context.Context, user domain.User) error
+	Update(ctx context.Context, user domain.User) error
+	Delete(ctx context.Context, userId string) error
 }


### PR DESCRIPTION
## Summary
- extend repository and api ports with user CRUD methods
- implement create, update and delete in the ORM repository
- provide use cases for user management in the core application
- expose HTTP endpoints for user creation, update and deletion
- document new routes in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872a1c98224832999de9a0f015dc114