### PR TITLE
Add Docker setup with compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.22 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o notification-system ./cmd/api
+
+FROM alpine:3.19
+WORKDIR /app
+COPY --from=builder /app/notification-system .
+COPY .env.example .env
+EXPOSE 4000
+CMD ["./notification-system"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ Domain modelleri (`domain` paketi) yalnizca gerekli alanlari barindirir ve dis k
 3. HTTP servisi varsayilan olarak Fiber uzerinde belirttiginiz portta calisir ve `/api/notifications/trigger` rotasi ile bildirim tetikler.
 4. Kullanici islemleri icin `/api/users` (POST), `/api/users/:id` (PUT, DELETE) rotalari kullanilabilir.
 
+## Docker ile Çalıştırma
+
+Projenin tum bagimliliklarini Docker uzerinden calistirmak icin asagidaki komutu kullanabilirsiniz. Bu komut MySQL, MailPit ve uygulamayi bir arada baslatir:
+
+```bash
+docker compose up --build
+```
+
+Uygulama `localhost:4000` uzerinden erisilebilir. MailPit arayuzune `localhost:8025` adresinden ulasabilirsiniz.
+
 ## Sonuc
 
 Bu proje, hexagonal mimariyi kullanarak sade ama genisletilebilir bir bildirim altyapisi sunar. Port ve adapter yapisi sayesinde kodun test edilebilirligi artar, dis bagimliliklarin degismesi kolaylasir ve gelisime acik bir temel olusur.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.9"
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: notification-system
+      MYSQL_USER: app
+      MYSQL_PASSWORD: app
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+  app:
+    build: .
+    depends_on:
+      - db
+      - mailpit
+    environment:
+      APPLICATION_PORT: 4000
+      DSN: app:app@tcp(db:3306)/notification-system?charset=utf8mb4&parseTime=True&loc=Local
+      MAIL_DRIVER: smtp
+      MAIL_HOST: mailpit
+      MAIL_PORT: 1025
+      MAIL_USER: ""
+      MAIL_PASSWORD: ""
+      SMS_DRIVER: log
+      PUSH_DRIVER: log
+      BASIC_AUTH_USERNAME: ""
+      BASIC_AUTH_PASSWORD: ""
+    ports:
+      - "4000:4000"
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for the application
- provide docker-compose.yml with MySQL and MailPit services
- document Docker usage in README

## Testing
- `go vet ./...`
- `go build ./cmd/api`


------
https://chatgpt.com/codex/tasks/task_e_68736d07aec883299bc8ff952d1226a6